### PR TITLE
MPI-41 remove unused dependency

### DIFF
--- a/src/components/QuickStartPreset.tsx
+++ b/src/components/QuickStartPreset.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import React, { useState } from "react";
+import  { useState } from "react";
 import { Timer } from "lucide-react";
 
 interface Params{


### PR DESCRIPTION
The build process failed because the React dependency was not used in the code and the build is validating not required dependencies