### PR TITLE
Fix/mpi 69 background music

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - fix/mpi-69-background-music 
 
 jobs:
   deploy: 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - fix/mpi-69-background-music 
 
 jobs:
   deploy: 

--- a/src/config/soundConfig.ts
+++ b/src/config/soundConfig.ts
@@ -1,8 +1,9 @@
 import { HowlOptions } from 'howler';
+import backgroundSound from '../assets/sounds/Background.mp3';
 
 export const soundConfig: Record<string, HowlOptions> = {
   "4-7-8": {
-    src: ['/sounds/Background.mp3'],
+    src: [backgroundSound],
     loop: true,
     volume: 0.3,
   },


### PR DESCRIPTION
Fixed audio loading error where background music files were not found in deployment. The issue was caused by audio files being located in public/sounds/ which were not being properly processed by Vite during build.